### PR TITLE
ci: add Firebase Hosting deploy action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,31 @@
+name: Deploy to Firebase Hosting
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Deploy to Firebase Hosting
+        uses: FirebaseExtended/action-hosting-deploy@v0
+        with:
+          repoToken: ${{ secrets.GITHUB_TOKEN }}
+          firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
+          projectId: 897162713550
+          channelId: live


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that builds and deploys to Firebase Hosting on every push to `main`
- Uses the existing `FIREBASE_SERVICE_ACCOUNT` secret for authentication

## Test plan
- [ ] Merge and confirm the Action triggers in the Actions tab
- [ ] Verify the site deploys successfully to Firebase Hosting